### PR TITLE
Escaped wildcards while unzipping

### DIFF
--- a/zip.lisp
+++ b/zip.lisp
@@ -217,7 +217,9 @@
          (utf8p (or (logtest (cd/flags header) 2048) *force-utf-8*)))
     (assert (= (cd/signature header) #x02014b50))
     (read-sequence name s)
-    (setf name (decode-name name utf8p))
+    (setf name #+sbcl (namestring (sb-impl::parse-native-namestring
+				   (decode-name name utf8p)))
+	       #-sbcl (decode-name name utf8p))
     (file-position s (+ (file-position s) (cd/extra-length header)))
     (when comment
       (read-sequence comment s)


### PR DESCRIPTION
Directory may contain files/directories with wild names. 
To be handled by Common Lisp (on `unzip`), some characters must be preceded by `#\\`.
For instance, here is for `#\[`:
```lisp
CL-USER>
(let ((dir #P"/tmp/arch098765/"))
  (ensure-directories-exist dir)
  (alexandria:write-string-into-file " "
				     (cl-fad:merge-pathnames-as-file dir #P"\\[a].html")
				     :if-exists :supersede)
  (zip:zip #P"/tmp/arch098765.zip" dir :if-exists :supersede)
  (zip:unzip #P"/tmp/arch098765.zip" #P"/tmp/arch098765-1/" :if-exists :supersede))
```
But names lose backslashes by `sb-impl::native-namestring` when `zip`ped, so failing on `unzip`:
```
bad place for a wild pathname
   [Condition of type SB-INT:SIMPLE-FILE-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {1001FC7FA3}>)

Backtrace:
  0: (ENSURE-DIRECTORIES-EXIST #P"/tmp/arch098765-1/[a].html" :VERBOSE NIL :MODE 511)
  1: (ZIP:UNZIP #P"/tmp/arch098765.zip" #P"/tmp/arch098765-1/" :IF-EXISTS :SUPERSEDE :VERBOSE NIL :FORCE-UTF-8 NIL)
```
To restore backslashes `sb-impl::parse-native-namestring` has been used.
This fix is supposed to cover SBCL at least. Actually, I got no idea whether this problem comes up on other implementations.
