### PR TITLE
Exposed with-zipfile-stream outside of package.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -6,21 +6,22 @@
 	   #:open-zipfile
 	   #:close-zipfile
 	   #:with-zipfile
+	   #:with-zipfile-stream
 	   #:zipfile-entries
 	   #:get-zipfile-entry
 	   #:zipfile-entry-name
-           #:zipfile-entry-size
-           #:zipfile-entry-comment
+	   #:zipfile-entry-size
+	   #:zipfile-entry-comment
 	   #:do-zipfile-entries
 	   #:zipfile-entry-contents
 	   #:unzip
 
-           #:with-output-to-zipfile     ;writing ZIP files
-           #:write-zipentry
-           #:zip
+	   #:with-output-to-zipfile     ;writing ZIP files
+	   #:write-zipentry
+	   #:zip
 
-           #:inflate                    ;inflate.lisp
-           #:skip-gzip-header
+	   #:inflate                    ;inflate.lisp
+	   #:skip-gzip-header
 
-           #:compress                   ;deflate.lisp
-           #:store))
+	   #:compress                   ;deflate.lisp
+	   #:store))


### PR DESCRIPTION
It doesn't appear to be used anywhere internally, I assume it was
intended to be part of the public API initially.

I needed it to process downloaded ZIP  archives in memory i.e.

```
(zip::with-zipfile-stream (file (flexi-streams:make-in-memory-input-stream in-mem-usb8-vector))
        (zip:do-zipfile-entries (name entry file)
          (format t "~a ~a ~a~%" name entry (zip:zipfile-entry-contents entry))))
```