### PR TITLE
Use UIOP if present to parse filenames

### DIFF
--- a/zip.lisp
+++ b/zip.lisp
@@ -658,7 +658,10 @@
     (do-zipfile-entries (name entry zip)
       (let* (#+nil (name (ppcre:regex-replace-all "[/*?]" name "_"))
              #+nil (name (subseq name 0 (min (length name) 128)))
-             (filename (merge-pathnames name target-directory)))
+             (filename (merge-pathnames 
+                        #+ASDF (uiop:ensure-pathname name)
+                        #-ASDF name
+                        target-directory)))
         (ensure-directories-exist filename)
         (unless (char= (elt name (1- (length name))) #\/)
           (ecase verbose

--- a/zip.lisp
+++ b/zip.lisp
@@ -658,9 +658,10 @@
     (do-zipfile-entries (name entry zip)
       (let* (#+nil (name (ppcre:regex-replace-all "[/*?]" name "_"))
              #+nil (name (subseq name 0 (min (length name) 128)))
-             (filename (merge-pathnames 
-                        #+ASDF (uiop:ensure-pathname name)
-                        #-ASDF name
+             (filename (merge-pathnames
+                        ;; Present in ASDF 3.0.0, not present in 2.000
+                        #+ASDF3 (uiop:ensure-pathname name)
+                        #-ASDF3 name
                         target-directory)))
         (ensure-directories-exist filename)
         (unless (char= (elt name (1- (length name))) #\/)


### PR DESCRIPTION
If zip files contain pathnames which look wild to implementations they will be so parsed, causing `unzip` to fail.  So in particular, since SBCL has support for wild pathnames which contain `[...]`, it will parse names like `[foo].xml` as wild.  These names do occur in some zip files created by proprietary applications.

SBCL is not at fault here.

A workaround is to use a pathname-parser which doesn't do this: UIOP provides one such and is commonly installed.  So this pull request changes `unzip` to use its parser, if ASDF is installed.

There may be other similar changes needed.